### PR TITLE
Provide a way to attach a context to gorp.DbMap

### DIFF
--- a/db_map_test.go
+++ b/db_map_test.go
@@ -102,17 +102,13 @@ func (suite *DbMapTestSuite) TestAttachContext() {
 	})
 
 	suite.T().Run("Transaction AttachContext", func(t *testing.T) {
-		t.Skip("Transactions not supported for Sqlite")
 		ctx := context.Background()
-		woutCtx, err := suite.Exec.(*DbMap).Begin(1 * time.Second)
-		if err != nil {
-			t.Error(err)
-			t.FailNow()
-		}
-		withCtx := woutCtx.AttachContext(ctx).(*Transaction)
+		dbm := suite.Exec.(*DbMap)
+		txWoutCtx := &Transaction{Transaction: gorp.Transaction{}, dbmap: dbm}
+		txWithCtx := txWoutCtx.AttachContext(ctx).(*Transaction)
 
-		suite.NotEqual(woutCtx, withCtx)
-		suite.NotEqual(woutCtx.Transaction, withCtx.Transaction)
+		suite.NotEqual(txWoutCtx, txWithCtx)
+		suite.NotEqual(txWoutCtx.Transaction, txWithCtx.Transaction)
 	})
 }
 


### PR DESCRIPTION
The `WithContext` function that `groq.DbMap` inherits returns a `gorp.SqlExecutor` instance rather than a `gorq.SqlExecutor` instance.

This PR adds a new `AttachContext` function which will run the `WithContext` function on the `gorp.SqlExecutor` instance and return a copy of the `gorq.SqlExecutor` so we can create query plans that run with a context while leaving the original `gorq.SqlExecutor` and `gorp.SqlExecutor` instances untouched

This PR also makes the tests pass by skipping the `Begin` test since it'd take a larger refactor to make it pass

[Asana](https://app.asana.com/0/1115876435717248/1119559000982454/f)